### PR TITLE
[gdal] Add SHA256 for gdal tarball

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -2,6 +2,7 @@ class Gdal < Formula
   desc "Geospatial Data Abstraction Library"
   homepage "http://www.gdal.org/"
   url "http://download.osgeo.org/gdal/2.2.3/gdal-2.2.3.tar.gz"
+  sha256 "52f01bda8968643633016769607e6082a8ba1c746fadc2c1abe12cf7dc8f61dd"
 
   depends_on "libpng"
   depends_on "libtiff"


### PR DESCRIPTION
Without this Homebrew complains:
```
==> Downloading http://download.osgeo.org/gdal/2.2.3/gdal-2.2.3.tar.gz
Warning: Cannot verify integrity of 7aa1587e93d7e908aa6582e3024fd758c31cea9e5711573f1b7724bb384d826f--gdal-2.2.3.tar.gz
A checksum was not provided for this resource
For your reference the SHA256 is: 52f01bda8968643633016769607e6082a8ba1c746fadc2c1abe12cf7dc8f61dd
```

I verified the checksum independently.